### PR TITLE
fix some link error

### DIFF
--- a/docs/cita/account-permission/permission.md
+++ b/docs/cita/account-permission/permission.md
@@ -394,7 +394,7 @@ $ cita-cli scm Authorization queryPermissions \
 [权限系统接口]: ../sys-contract-interface/interface#权限系统合约
 [权限系统操作示例]: ./permission-example
 [测试合约]: https://github.com/citahub/test-contracts/blob/master/SimpleStorage.sol
-[生成账户]: ../advanced-use/contracts/solidity
+[生成账户]: ../advanced-use/contracts/solidity#生成账户
 [调用合约]: ../advanced-use/contracts/solidity#调用
 [账户概述]: ./account#账户概述
 [运行 CITA]: ../getting-started/run-cita

--- a/docs/cita/faq.md
+++ b/docs/cita/faq.md
@@ -225,7 +225,7 @@ CITA 采用的微服务架构，微服务之间通过消息总线通信。消息
 
 #### 目前 CITA 底层区块数据不断增长，占用空间很大，需要有办法压缩区块及日志数据，目前CITA有支持吗？
 做快照是可以减少目录大小，但老的数据会丢失。
-日志可以清理掉或者备份到其他服务器上，参考 CITA 文档：https://docs.citahub.com/en-US/next/cita/system/log
+日志可以清理掉或者备份到其他服务器上，参考 CITA 文档：https://docs.citahub.com/zh-CN/cita/ops/log
 
 ### 日志
 

--- a/docs/cita/getting-started/setup.md
+++ b/docs/cita/getting-started/setup.md
@@ -38,18 +38,18 @@ title: 环境准备
 3. 下载 CITA-CLI 安装包
 
    ```shell
-   $ wget https://github.com/citahub/cita-cli/releases/download/0.19.6/cita-cli-x86_64-musl-tls-0.19.6.tar.gz
+   $ wget https://github.com/citahub/cita-cli/releases/download/0.19.7/cita-cli-x86_64-musl-tls-0.19.7.tar.gz
    ```
 
    > 注：这里所下载的是 CITA-CLI 是 Linux 系统下的二进制发布包，如果你使用 macOS，请按以下命令下载对应系统的 CITA-CLI：
    >
-   > $ wget https://github.com/citahub/cita-cli/releases/download/0.19.6/cita-cli-x86_64-mac-osx-tls-0.19.6.tar.gz
+   > $ wget https://github.com/citahub/cita-cli/releases/download/0.19.7/cita-cli-x86_64-mac-osx-tls-0.19.7.tar.gz
    >
 
 4. 解压程序
 
    ```shell
-   $ tar zxvf cita-cli-x86_64-musl-tls-0.19.6.tar.gz
+   $ tar zxvf cita-cli-x86_64-musl-tls-0.19.7.tar.gz
    ```
 
 5. 复制 CITA-CLI 到 系统可执行文件目录下
@@ -69,7 +69,7 @@ title: 环境准备
 2. 下载 CITA 安装包
 
    ```shell
-   $ wget https://github.com/citahub/cita/releases/download/v1.0.0/cita_secp256k1_sha3.tar.gz
+   $ wget https://github.com/citahub/cita/releases/download/v1.0.1/cita_secp256k1_sha3.tar.gz
    ```
 
 3. 解压 CITA 程序

--- a/docs/cita/node/cons-node.md
+++ b/docs/cita/node/cons-node.md
@@ -279,7 +279,7 @@ CITA 作为许可链共识节点采用轮流出块的方式进行出块。作为
 [stakePermillage 接口] 可查询共识节点出块权重千分比（目前只对 Charge 模型开放）。
 
 [共识节点管理系统合约]: ../sys-contract-interface/interface#interface#approveNode
-[setStake 接口]: https://docs.citahub.com/zh-CN/0.23.0/cita/system-contract-interface/interface#setstake
+[setStake 接口]: ../sys-contract-interface/interface#setstake
 [solc]: https://solidity-cn.readthedocs.io/zh/develop/installing-solidity.html
 [超级管理员账户信息]: ../getting-started/run-cita
 [cita-cli]: https://github.com/citahub/cita-cli


### PR DESCRIPTION
1. Transaction.java 跳转地址失败
2. cita-cli版本改为0.19.7
3. cita版本改为1.0.1
4. https://docs.citahub.com/en-US/next/cita/system/log 地址失败
5. stakePermillage 接口 链接失效