### PR TITLE
rpc getblockbyhash height params  support 0X or decimal so delete invalid  params example

### DIFF
--- a/docs/cita/rpc-guide/rpc.md
+++ b/docs/cita/rpc-guide/rpc.md
@@ -360,18 +360,6 @@ Request：
 $ curl -X POST --data '{"jsonrpc":"2.0","method":"getBlockByNumber","params":["0xF9", true],"id":1}' 127.0.0.1:1337 | jq
 ```
 
-* Invalid Params
-
-```shell
-$ curl -X POST --data '{"jsonrpc":"2.0","method":"getBlockByNumber","params":["0XF9", true],"id":1}' 127.0.0.1:1337 | jq
-```
-
-或者
-
-```shell
-$ curl -X POST --data '{"jsonrpc":"2.0","method":"getBlockByNumber","params":[249, true],"id":1}' 127.0.0.1:1337 | jq
-```
-
 高度参数可以用 0x 开头的十六进制。0x 开头或者十进制整数都是错误的参数格式。
 
 结果同 [getBlockByHash](#getblockbyhash)

--- a/website/versioned_docs/version-20.2.0/cita/rpc-guide/rpc.md
+++ b/website/versioned_docs/version-20.2.0/cita/rpc-guide/rpc.md
@@ -360,18 +360,6 @@ Request:
 $ curl -X POST --data '{"jsonrpc":"2.0","method":"getBlockByNumber","params":["0xF9", true],"id":1}' 127.0.0.1:1337 | jq
 ```
 
-* Invalid Params
-
-```shell
-$ curl -X POST --data '{"jsonrpc":"2.0","method":"getBlockByNumber","params":["0XF9", true],"id":1}' 127.0.0.1:1337 | jq
-```
-
-或者
-
-```shell
-$ curl -X POST --data '{"jsonrpc":"2.0","method":"getBlockByNumber","params":[249, true],"id":1}' 127.0.0.1:1337 | jq
-```
-
 高度参数可以用 0x 开头的十六进制。0x 开头或者十进制整数都是错误的参数格式。
 
 结果同 [getBlockByHash](#getblockbyhash)


### PR DESCRIPTION
rpc getblockbyhash height params  support 0X or decimal so delete invalid  params example